### PR TITLE
move run out of Engine init

### DIFF
--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -73,9 +73,7 @@ class Engine(ABC):
                 self.log.warning("Failed to close engine input socket after setup failure: %s", e)
             raise
 
-        # autostart if enabled
-        if getattr(self.settings, "engine_autostart", True):
-            self.start()
+        self.log.debug("Engine initialized and ready.")
 
     def _setup_output_sockets(self) -> None:
         """Create and connect output sockets for all destinations in out_addr.


### PR DESCRIPTION
relates to issue #32

When Engine.__init__ calls self.start(), it triggers the start method in Service (the subclass). If Service hasn't finished its own __init__ logic, or if the base class assumes a specific state that the subclass hasn't established yet, things break.

this PR
- decouples initialization form execution, remove the autostart logic from the Engine constructor
- run in final subclass becomes single point of entry for the execution loop and manages autostart logic
