### PR TITLE
update github workflow to use the right DetectMateLibrary branch for testing.

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,14 +28,15 @@ jobs:
         activate-environment: true
         enable-cache: true
 
+    # include following code into the run section to match DetectMateService and DetectMateLibrary branches, if the name matches.
+    # elif git ls-remote --heads "$REPO_URL" "$CURRENT_BRANCH" | grep -q .; then
+    #   echo "LIB_BRANCH=$CURRENT_BRANCH" >> $GITHUB_ENV
     - name: Resolve DetectMateLibrary branch
       run: |
         CURRENT_BRANCH="${{ github.ref_name }}"
         REPO_URL="https://github.com/ait-detectmate/DetectMateLibrary.git"
         if [ "$CURRENT_BRANCH" = "main" ]; then
           echo "LIB_BRANCH=main" >> $GITHUB_ENV
-        elif git ls-remote --heads "$REPO_URL" "$CURRENT_BRANCH" | grep -q .; then
-          echo "LIB_BRANCH=$CURRENT_BRANCH" >> $GITHUB_ENV
         else
           echo "LIB_BRANCH=development" >> $GITHUB_ENV
         fi


### PR DESCRIPTION
Fixes #41 

Please let me know if you really dislike the idea with using the combination of both existing branches (for example if feature/foo exists in DetectMateLibrary and DetectMateService), so I can remove it before merging.

main -> main
development -> development
feature/foo -> development
feature_fast_api_rewrite -> feature_fast_api_rewrite

Adds "development" to the branches where the workflow should be triggered.

