### PR TITLE
Fix dashboard

### DIFF
--- a/container/grafana/dashboards/detectmate.json
+++ b/container/grafana/dashboards/detectmate.json
@@ -632,8 +632,8 @@
         "list": []
     },
     "time": {
-        "from": "2026-05-19T13:50:40.517Z",
-        "to": "2026-05-19T14:15:32.481Z"
+        "from": "now-1h",
+        "to": "now"
     },
     "timepicker": {},
     "timezone": "browser",

--- a/container/grafana/provisioning/dashboards/dashboards.yml
+++ b/container/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: DetectMate
+    folder: DetectMate
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       volumes:
         - ./container/grafana/prometheus.yml:/etc/grafana/provisioning/datasources/prometheus.yml
         - ./container/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml
-        - ./container/grafana/dashboards:/etc/grafana/provisioning/dashboards
+        - ./container/grafana/dashboards:/var/lib/grafana/dashboards
         - grafana_data:/var/lib/grafana
 
           #    kafka:


### PR DESCRIPTION
# Task
<!-- Please add link a relevant issue or task -->

# Description
Adds a Grafana dashboard provisioning setup so the DetectMate Service Overview dashboard loads automatically when the stack starts, without requiring manual import. Fixes the dashboard time range from a hardcoded historical window to a rolling now-1h to now so panels display live data immediately on load.

# How Has This Been Tested?
The dashboard was verified by running 
docker compose down -v 
docker compose up -d 
and confirming the DetectMate Service Overview dashboard automatically in Grafana at http://localhost:3000

generated logs accodring to the getting started
-> dashboard visualizations show data form the last hour

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [ ] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
