### PR TITLE
Add prometheus lines metrics

### DIFF
--- a/container/grafana/dashboards/detectmate.json
+++ b/container/grafana/dashboards/detectmate.json
@@ -431,15 +431,53 @@
                             }
                         ]
                     },
-                    "unit": "s"
+                    "unit": "ms"
                 },
                 "overrides": [
                     {
                         "matcher": {
                             "id": "byRegexp",
-                            "options": ""
+                            "options": "^p50.*"
                         },
-                        "properties": []
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "green",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": "^p95.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "orange",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": "^p99.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "color",
+                                "value": {
+                                    "fixedColor": "red",
+                                    "mode": "fixed"
+                                }
+                            }
+                        ]
                     }
                 ]
             },
@@ -467,7 +505,7 @@
             "targets": [
                 {
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.5, sum by(le, component_type) (rate(processing_duration_seconds_bucket[1m])))",
+                    "expr": "histogram_quantile(0.5, sum by(le, component_type) (rate(processing_duration_seconds_bucket[1m]))) * 1000",
                     "legendFormat": "p50 {{component_type}}",
                     "range": true,
                     "refId": "A"
@@ -478,7 +516,7 @@
                         "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.95, sum by(le, component_type) (rate(processing_duration_seconds_bucket[$__rate_interval])))",
+                    "expr": "histogram_quantile(0.95, sum by(le, component_type) (rate(processing_duration_seconds_bucket[$__rate_interval]))) * 1000",
                     "instant": false,
                     "legendFormat": "p95 {{component_type}}",
                     "range": true,
@@ -490,7 +528,7 @@
                         "uid": "PBFA97CFB590B2093"
                     },
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.99, sum by(le, component_type) (rate(processing_duration_seconds_bucket[$__rate_interval])))",
+                    "expr": "histogram_quantile(0.99, sum by(le, component_type) (rate(processing_duration_seconds_bucket[$__rate_interval]))) * 1000",
                     "instant": false,
                     "legendFormat": "p99 {{component_type}}",
                     "range": true,
@@ -498,6 +536,176 @@
                 }
             ],
             "title": "Processing latency",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+            },
+            "description": "Current mean processing time per component, averaged over the last minute.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "orange",
+                                "value": 100
+                            },
+                            {
+                                "color": "red",
+                                "value": 500
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 24
+            },
+            "id": 8,
+            "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                    "valueSize": 50
+                },
+                "textMode": "value_and_name",
+                "wideLayout": true
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+                {
+                    "editorMode": "builder",
+                    "expr": "rate(processing_duration_seconds_sum[1m]) / rate(processing_duration_seconds_count[1m]) * 1000",
+                    "instant": true,
+                    "legendFormat": "{{component_type}}",
+                    "range": false,
+                    "refId": "A"
+                }
+            ],
+            "title": "Avg processing time (now)",
+            "type": "stat"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+            },
+            "description": "Mean processing time per component over time. Unlike percentiles, the mean is sensitive to all messages including outliers, making it useful for spotting gradual degradation.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "showValues": false,
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "ms"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 24,
+                "x": 0,
+                "y": 32
+            },
+            "id": 9,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+                {
+                    "editorMode": "builder",
+                    "expr": "rate(processing_duration_seconds_sum[1m]) / rate(processing_duration_seconds_count[1m]) * 1000",
+                    "legendFormat": "{{component_type}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Mean processing time (ms)",
             "type": "timeseries"
         },
         {
@@ -567,7 +775,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 32
+                "y": 40
             },
             "id": 1,
             "options": {
@@ -623,6 +831,248 @@
             ],
             "title": "Throughput (bytes/s)",
             "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+            },
+            "description": "Lines received at the input socket per second, per component. Counts every line regardless of whether it was successfully processed. A drop to zero means no data is reaching the component.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "showValues": false,
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "lines/s"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": ".*MatcherParser.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "MatcherParser"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": ".*NewValueDetector.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "NewValueDetector"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 48
+            },
+            "id": 6,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+                {
+                    "editorMode": "builder",
+                    "expr": "rate(data_read_lines_total[1m])",
+                    "legendFormat": "{{component_type}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Input rate (lines/s)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+            },
+            "description": "Lines successfully written to output interfaces per second, per component. Counted once per message regardless of how many downstream interfaces exist. Compare with input rate to spot message loss.",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "barWidthFactor": 0.6,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "showValues": false,
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": 0
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "lines/s"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": ".*MatcherParser.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "MatcherParser"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": ".*NewValueDetector.*"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "NewValueDetector"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 48
+            },
+            "id": 7,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "hideZeros": false,
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "pluginVersion": "12.4.2",
+            "targets": [
+                {
+                    "editorMode": "builder",
+                    "expr": "rate(data_written_lines_total[1m])",
+                    "legendFormat": "{{component_type}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "Output rate (lines/s)",
+            "type": "timeseries"
         }
     ],
     "preload": false,
@@ -639,6 +1089,6 @@
     "timezone": "browser",
     "title": "DetectMateService Overview",
     "uid": "adfp6vw",
-    "version": 2,
+    "version": 3,
     "weekStart": ""
 }

--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -226,6 +226,7 @@ class Engine(ABC):
                     data_written_lines_total.labels(**labels).inc(out.count(b'\n') or 1)
                     self.log.debug("Engine: Reply sent on engine socket")
                 except pynng.NNGException as e:
+                    data_dropped_bytes_total.labels(**labels).inc(len(out))
                     self.log.error("Engine error sending reply on engine socket: %s", e)
                     continue
 
@@ -256,6 +257,7 @@ class Engine(ABC):
                 data_dropped_bytes_total.labels(**labels).inc(len(data))
                 self.log.warning(f"Engine: Output socket {i} not ready or disconnected, dropping message")
             except pynng.NNGException as e:
+                data_dropped_bytes_total.labels(**labels).inc(len(data))
                 self.log.error(f"Engine error sending to output socket {i}: {e}")
                 continue
         return any_sent

--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -16,9 +16,21 @@ data_read_bytes_total = Counter(
     ["component_type", "component_id"]
 )
 
+data_read_lines_total = Counter(
+    "data_read_lines_total",
+    "Total lines read from input interfaces",
+    ["component_type", "component_id"]
+)
+
 data_written_bytes_total = Counter(
     "data_written_bytes_total",
     "Total bytes written to output interfaces",
+    ["component_type", "component_id"]
+)
+
+data_written_lines_total = Counter(
+    "data_written_lines_total",
+    "Total lines written to output interfaces",
     ["component_type", "component_id"]
 )
 
@@ -165,8 +177,9 @@ class Engine(ABC):
                     self.log.debug("Engine: Received empty message, skipping")
                     continue
 
-                # TRACK read bytes
+                # TRACK read bytes and lines
                 data_read_bytes_total.labels(**labels).inc(len(raw))
+                data_read_lines_total.labels(**labels).inc(raw.count(b'\n') or 1)
 
                 self.log.debug(f"Engine: Received {len(raw)} bytes from socket")
             except pynng.Timeout:
@@ -185,9 +198,6 @@ class Engine(ABC):
             try:
                 self.log.debug("Engine: Calling processor.process()...")
                 out = self.processor.process(raw)
-                if out is not None:
-                    # TRACK written bytes
-                    data_written_bytes_total.labels(**labels).inc(len(out))
                 self.log.debug(f"Engine: Processor returned: {out!r}")
             except Exception as e:
                 self.log.exception("Engine error during process: %s", e)
@@ -200,7 +210,9 @@ class Engine(ABC):
             # send phase
             if self._out_sockets:
                 # Multi-destination mode: send to all configured outputs
-                self._send_to_outputs(out)
+                if self._send_to_outputs(out):
+                    data_written_bytes_total.labels(**labels).inc(len(out))
+                    data_written_lines_total.labels(**labels).inc(out.count(b'\n') or 1)
             else:
                 # Backwards-compatible mode: no outputs configured, reply on PAIR socket
                 try:
@@ -209,31 +221,35 @@ class Engine(ABC):
                         "sending reply back via engine socket"
                     )
                     self._pair_sock.send(out)
-                    # TRACK written bytes (Fallback mode)
+                    # TRACK written bytes and lines (Fallback mode)
                     data_written_bytes_total.labels(**labels).inc(len(out))
+                    data_written_lines_total.labels(**labels).inc(out.count(b'\n') or 1)
                     self.log.debug("Engine: Reply sent on engine socket")
                 except pynng.NNGException as e:
                     self.log.error("Engine error sending reply on engine socket: %s", e)
                     continue
 
-    def _send_to_outputs(self, data: bytes) -> None:
-        """Send processed data to all configured output destinations."""
+    def _send_to_outputs(self, data: bytes) -> bool:
+        """Send processed data to all configured output destinations.
+
+        Returns True if at least one send succeeded.
+        """
         labels = {
             "component_type": getattr(self, "component_type", "core"),
             "component_id": self.settings.component_id
         }
         if not self._out_sockets:
             self.log.debug("Engine: No output sockets configured, skipping send")
-            return
+            return False
 
+        any_sent = False
         for i, sock in enumerate(self._out_sockets):
             try:
                 self.log.debug(f"Engine: Sending {len(data)} bytes to output socket {i}")
                 # Non-blocking send is preferred to avoid stalling the engine loop
                 # Pair0 with block=False will raise TryAgain if the peer is disconnected
                 sock.send(data, block=False)
-                # TRACK written bytes
-                data_written_bytes_total.labels(**labels).inc(len(data))
+                any_sent = True
                 self.log.debug(f"Engine: Send completed to output socket {i}")
             except pynng.TryAgain:
                 # TRACK dropped bytes
@@ -242,6 +258,7 @@ class Engine(ABC):
             except pynng.NNGException as e:
                 self.log.error(f"Engine error sending to output socket {i}: {e}")
                 continue
+        return any_sent
 
     def stop(self) -> None | str:
         """Stop the engine loop and clean up resources.

--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -46,6 +46,12 @@ data_dropped_lines_total = Counter(
     ["component_type", "component_id"]
 )
 
+processing_errors_total = Counter(
+    "processing_errors_total",
+    "Total number of exceptions raised during process()",
+    ["component_type", "component_id"]
+)
+
 
 class EngineException(Exception):
     """Custom exception for engine-related errors."""
@@ -206,6 +212,7 @@ class Engine(ABC):
                 out = self.processor.process(raw)
                 self.log.debug(f"Engine: Processor returned: {out!r}")
             except Exception as e:
+                processing_errors_total.labels(**labels).inc()
                 self.log.exception("Engine error during process: %s", e)
                 continue
 

--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -40,6 +40,12 @@ data_dropped_bytes_total = Counter(
     ["component_type", "component_id"]
 )
 
+data_dropped_lines_total = Counter(
+    "data_dropped_lines_total",
+    "Total lines dropped due to disconnected or slow downstream peers",
+    ["component_type", "component_id"]
+)
+
 
 class EngineException(Exception):
     """Custom exception for engine-related errors."""
@@ -227,6 +233,7 @@ class Engine(ABC):
                     self.log.debug("Engine: Reply sent on engine socket")
                 except pynng.NNGException as e:
                     data_dropped_bytes_total.labels(**labels).inc(len(out))
+                    data_dropped_lines_total.labels(**labels).inc(out.count(b'\n') or 1)
                     self.log.error("Engine error sending reply on engine socket: %s", e)
                     continue
 
@@ -253,11 +260,12 @@ class Engine(ABC):
                 any_sent = True
                 self.log.debug(f"Engine: Send completed to output socket {i}")
             except pynng.TryAgain:
-                # TRACK dropped bytes
                 data_dropped_bytes_total.labels(**labels).inc(len(data))
+                data_dropped_lines_total.labels(**labels).inc(data.count(b'\n') or 1)
                 self.log.warning(f"Engine: Output socket {i} not ready or disconnected, dropping message")
             except pynng.NNGException as e:
                 data_dropped_bytes_total.labels(**labels).inc(len(data))
+                data_dropped_lines_total.labels(**labels).inc(data.count(b'\n') or 1)
                 self.log.error(f"Engine error sending to output socket {i}: {e}")
                 continue
         return any_sent


### PR DESCRIPTION
# Task
#146 

# Description
 **Adds 4 new counters**
- `data_read_lines_total` = lines received at the socket (before processing)
- `data_written_lines_total `= lines successfully sent (counted once per message regardless of number of output interfaces)
- `data_dropped_lines_total `= lines dropped due to peer not ready or socket errors
- `processing_errors_total` = exception during process()

**Fixes to existing `data_written_bytes_total`:**
  Previously double-counted (once in the process phase, again per send). Now counted **once** per message on successful send

**_Counting semantics (applies to both bytes and lines):_**
- read: incremented on recieve, irrespective of processing outcome
- written: incremented once per message **on at least one successful send**
- dropped: incremented per failing output interface (TryAgain and NNGException in both multi-dest and fallback send paths)

**Changes to Grafana visualizations:**
 Existing p50/95/99 panel:
- Unit switched to ms 
- changes colors Colors: p50 → green, p95 → orange, p99 → red

New stat panel ("Avg processing time (now)":
- Shows current mean per component as a number with color thresholds (green < 100ms, orange < 500ms, red above)
  
New time-series panel ("Mean processing time (ms)":
- sum / count * 1000 per component, unit ms,  trend over time



# How Has This Been Tested?
run the getting started with docker
create anomalies
check grafana on localhost:3000/dashboards

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
