### PR TITLE
Feature tls tcp

### DIFF
--- a/src/service/features/engine.py
+++ b/src/service/features/engine.py
@@ -110,7 +110,9 @@ class Engine(ABC):
         self._engine_socket_factory: EngineSocketFactory = (
             socket_factory if socket_factory is not None else NngPairSocketFactory()
         )
-        self._pair_sock = self._engine_socket_factory.create(addr, self.log)
+        self._pair_sock = self._engine_socket_factory.create(
+            addr, self.log, tls_config=self.settings.tls_input
+        )
         self._pair_sock.recv_timeout = self.settings.engine_recv_timeout
 
         # set up output sockets for multiple destinations
@@ -149,6 +151,22 @@ class Engine(ABC):
                 # Set buffer sizes to 0 to minimize buffering and drop messages if peer not ready
                 sock.send_buffer_size = 0
                 sock.recv_buffer_size = 0
+
+                if addr_str.startswith("tls+tcp://"):
+                    tls_out = self.settings.tls_output
+                    # model_validator should catch this actuallyat startup
+                    if tls_out is None:
+                        sock.close()
+                        raise ValueError(
+                            f"Output address {addr_str} uses tls+tcp:// but tls_output "
+                            "is not configured. Add a tls_output block with ca_file."
+                        )
+                    cfg = pynng.TLSConfig(
+                        pynng.TLSConfig.MODE_CLIENT,
+                        ca_files=str(tls_out.ca_file),
+                        server_name=tls_out.server_name,
+                    )
+                    sock.tls_config = cfg
 
                 # Non-blocking dial: returns immediately, connects in background
                 sock.dial(addr_str, block=False)

--- a/src/service/features/engine_socket.py
+++ b/src/service/features/engine_socket.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol, runtime_checkable, cast
+from typing import Optional, Protocol, runtime_checkable, cast
 import logging
 import pynng
 import errno
 from urllib.parse import urlparse
+from service.settings import TlsInputConfig
 
 
 @runtime_checkable
@@ -23,13 +24,23 @@ class EngineSocketFactory(Protocol):
     """Factory that creates bound EngineSocket instances for a given
     address."""
 
-    def create(self, addr: str, logger: logging.Logger) -> EngineSocket: ...
+    def create(
+        self,
+        addr: str,
+        logger: logging.Logger,
+        tls_config: Optional[TlsInputConfig] = None,
+    ) -> EngineSocket: ...
 
 
 class NngPairSocketFactory:
     """Default factory using pynng.Pair0 and binding to the given address."""
 
-    def create(self, addr: str, logger: logging.Logger) -> EngineSocket:
+    def create(
+        self,
+        addr: str,
+        logger: logging.Logger,
+        tls_config: Optional[TlsInputConfig] = None,
+    ) -> EngineSocket:
         sock = pynng.Pair0()
         parsed = urlparse(addr)
         if parsed.scheme == "ipc":
@@ -46,6 +57,18 @@ class NngPairSocketFactory:
             if not parsed.port:
                 raise ValueError(f"Missing port in TCP address: {addr}")
 
+        elif parsed.scheme == "tls+tcp":
+            if tls_config is None:
+                sock.close()
+                raise ValueError(
+                    f"Address {addr} uses tls+tcp:// but no TLS config was provided. "
+                    "Set tls_input in your settings."
+                )
+            cfg = pynng.TLSConfig(
+                pynng.TLSConfig.MODE_SERVER,
+                cert_key_file=str(tls_config.cert_key_file),
+            )
+            sock.tls_config = cfg
         try:
             sock.listen(addr)
             return cast(EngineSocket, sock)  # use cast to tell mypy this implements EngineSocket

--- a/src/service/settings.py
+++ b/src/service/settings.py
@@ -3,9 +3,28 @@ from pathlib import Path
 from uuid import uuid5, NAMESPACE_URL
 from typing import Any, Dict, Optional, List, Annotated, Union
 import yaml
-from pydantic import ValidationError, model_validator, UrlConstraints, field_serializer, Field
+from pydantic import BaseModel, ValidationError, model_validator, UrlConstraints, field_serializer, Field
 from pydantic_core import Url
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class TlsInputConfig(BaseModel):
+    """TLS configuration for the input/listener socket.
+
+    Required when engine_addr uses the tls+tcp:// scheme. Supports plain
+    TLS only
+    """
+    cert_key_file: Path
+
+
+class TlsOutputConfig(BaseModel):
+    """TLS configuration for output/dialer sockets.
+
+    Required when any address in out_addr uses the tls+tcp scheme.
+    Supports plain TLS only
+    """
+    ca_file: Path               # CA cert used to verify the server certificate
+    server_name: Optional[str] = None  # SNI override when hostname differs from cert CN
 
 
 # Output address URL types
@@ -48,6 +67,10 @@ class ServiceSettings(BaseSettings):
     # timeout for output dials. Used with blocking dial in Engine
     out_dial_timeout: int = 1000  # milliseconds
 
+    # TLS configuration — required when the corresponding address uses tls+tcp://
+    tls_input: Optional[TlsInputConfig] = None
+    tls_output: Optional[TlsOutputConfig] = None
+
     # HTTP server (FastAPI) settings
     http_host: str = "127.0.0.1"
     http_port: int = 8000
@@ -86,6 +109,24 @@ class ServiceSettings(BaseSettings):
         #    This stays the same as long as the addresses don't change.
         base = f"{self.component_type}|{self.engine_addr or ''}"
         self.component_id = self._generate_uuid_from_string(f"detectmate/{base}")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_tls_config_present(self) -> "ServiceSettings":
+        """Fail at startup if a tls+tcp address is used without the matching
+        TLS config."""
+        if self.engine_addr and self.engine_addr.startswith("tls+tcp://"):
+            if self.tls_input is None:
+                raise ValueError(
+                    "engine_addr uses tls+tcp:// but tls_input is not configured. "
+                    "Add a tls_input block with cert_key_file."
+                )
+        if any(str(addr).startswith("tls+tcp://") for addr in self.out_addr):
+            if self.tls_output is None:
+                raise ValueError(
+                    "out_addr contains a tls+tcp:// address but tls_output is not configured. "
+                    "Add a tls_output block with ca_file."
+                )
         return self
 
     @classmethod

--- a/tests/test_tls_settings.py
+++ b/tests/test_tls_settings.py
@@ -1,0 +1,207 @@
+"""Tests for TLS configuration models and ServiceSettings cross-validation."""
+import pytest
+from pydantic import ValidationError
+
+from service.settings import ServiceSettings, TlsInputConfig, TlsOutputConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Common non-TLS settings kwargs reused across tests
+_BASE = dict(
+    engine_addr="ipc:///tmp/test_tls_settings.engine.ipc",
+    http_host="127.0.0.1",
+    http_port=8099,
+    engine_autostart=False,
+    log_to_file=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# TlsInputConfig model
+# ---------------------------------------------------------------------------
+
+def test_tls_input_config_accepts_valid_path(tmp_path):
+    """TlsInputConfig constructs correctly with a path to cert_key_file."""
+    cert = tmp_path / "server.pem"
+    cert.touch()
+    cfg = TlsInputConfig(cert_key_file=cert)
+    assert cfg.cert_key_file == cert
+
+
+def test_tls_input_config_requires_cert_key_file():
+    """TlsInputConfig raises ValidationError when cert_key_file is missing."""
+    with pytest.raises(ValidationError):
+        TlsInputConfig()
+
+
+# ---------------------------------------------------------------------------
+# TlsOutputConfig model
+# ---------------------------------------------------------------------------
+
+def test_tls_output_config_accepts_valid_ca_file(tmp_path):
+    """TlsOutputConfig constructs correctly with just ca_file."""
+    ca = tmp_path / "ca.pem"
+    ca.touch()
+    cfg = TlsOutputConfig(ca_file=ca)
+    assert cfg.ca_file == ca
+    assert cfg.server_name is None
+
+
+def test_tls_output_config_accepts_optional_server_name(tmp_path):
+    """TlsOutputConfig accepts an optional server_name for SNI override."""
+    ca = tmp_path / "ca.pem"
+    ca.touch()
+    cfg = TlsOutputConfig(ca_file=ca, server_name="detector")
+    assert cfg.server_name == "detector"
+
+
+def test_tls_output_config_requires_ca_file():
+    """TlsOutputConfig raises ValidationError when ca_file is missing."""
+    with pytest.raises(ValidationError):
+        TlsOutputConfig()
+
+
+# ---------------------------------------------------------------------------
+# ServiceSettings cross-validation: missing TLS config blocks
+# ---------------------------------------------------------------------------
+
+def test_tls_tcp_engine_addr_without_tls_input_raises():
+    """Starting with a tls+tcp engine_addr but no tls_input fails at
+    validation."""
+    with pytest.raises((ValueError, ValidationError), match="tls_input"):
+        ServiceSettings(
+            **{**_BASE, "engine_addr": "tls+tcp://0.0.0.0:15000"},
+        )
+
+
+def test_tls_tcp_out_addr_without_tls_output_raises():
+    """Having a tls+tcp address in out_addr but no tls_output fails at
+    validation."""
+    with pytest.raises((ValueError, ValidationError), match="tls_output"):
+        ServiceSettings(
+            **{**_BASE, "out_addr": ["tls+tcp://detector:15001"]},
+        )
+
+
+def test_tls_tcp_out_addr_mixed_with_non_tls_without_tls_output_raises():
+    """Even one tls+tcp address in out_addr requires tls_output to be set."""
+    with pytest.raises((ValueError, ValidationError), match="tls_output"):
+        ServiceSettings(
+            **{**_BASE, "out_addr": [
+                "ipc:///tmp/plain.ipc",
+                "tls+tcp://detector:15002",
+            ]},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ServiceSettings cross-validation: valid configurations
+# ---------------------------------------------------------------------------
+
+def test_non_tls_addrs_do_not_require_tls_config():
+    """Ipc and tcp addresses work fine without any TLS config blocks."""
+    settings = ServiceSettings(
+        **{**_BASE, "out_addr": ["ipc:///tmp/out.ipc", "tcp://localhost:15003"]},
+    )
+    assert settings.tls_input is None
+    assert settings.tls_output is None
+
+
+def test_tls_tcp_engine_addr_with_tls_input_is_valid(tmp_path):
+    """Tls+tcp engine_addr + tls_input block passes validation."""
+    cert = tmp_path / "server.pem"
+    cert.touch()
+    settings = ServiceSettings(
+        **{**_BASE,
+           "engine_addr": "tls+tcp://0.0.0.0:15004",
+           "tls_input": {"cert_key_file": str(cert)}},
+    )
+    assert settings.tls_input is not None
+    assert settings.tls_input.cert_key_file == cert
+
+
+def test_tls_tcp_out_addr_with_tls_output_is_valid(tmp_path):
+    """Tls+tcp out_addr + tls_output block passes validation."""
+    ca = tmp_path / "ca.pem"
+    ca.touch()
+    settings = ServiceSettings(
+        **{**_BASE,
+           "out_addr": ["tls+tcp://detector:15005"],
+           "tls_output": {"ca_file": str(ca), "server_name": "detector"}},
+    )
+    assert settings.tls_output is not None
+    assert settings.tls_output.server_name == "detector"
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+def test_settings_from_yaml_with_tls_input(tmp_path):
+    """tls_input block is loaded correctly from a YAML file."""
+    cert = tmp_path / "server.pem"
+    cert.touch()
+
+    yaml_content = f"""
+engine_addr: "tls+tcp://0.0.0.0:15008"
+http_host: "127.0.0.1"
+http_port: 8100
+engine_autostart: false
+log_to_file: false
+tls_input:
+  cert_key_file: "{cert}"
+"""
+    yaml_file = tmp_path / "settings.yaml"
+    yaml_file.write_text(yaml_content)
+
+    settings = ServiceSettings.from_yaml(yaml_file)
+
+    assert settings.tls_input is not None
+    assert settings.tls_input.cert_key_file == cert
+
+
+def test_settings_from_yaml_with_tls_output(tmp_path):
+    """tls_output block is loaded correctly from a YAML file."""
+    ca = tmp_path / "ca.pem"
+    ca.touch()
+
+    yaml_content = f"""
+engine_addr: "ipc:///tmp/test.ipc"
+http_host: "127.0.0.1"
+http_port: 8101
+engine_autostart: false
+log_to_file: false
+out_addr:
+  - "tls+tcp://detector:15009"
+tls_output:
+  ca_file: "{ca}"
+  server_name: "detector"
+"""
+    yaml_file = tmp_path / "settings.yaml"
+    yaml_file.write_text(yaml_content)
+
+    settings = ServiceSettings.from_yaml(yaml_file)
+
+    assert settings.tls_output is not None
+    assert settings.tls_output.ca_file == ca
+    assert settings.tls_output.server_name == "detector"
+
+
+def test_settings_from_yaml_tls_tcp_without_config_raises(tmp_path):
+    """from_yaml raises SystemExit (wraps ValueError) if tls+tcp addr has no
+    TLS block."""
+    yaml_content = """
+engine_addr: "tls+tcp://0.0.0.0:15010"
+http_host: "127.0.0.1"
+http_port: 8102
+engine_autostart: false
+log_to_file: false
+"""
+    yaml_file = tmp_path / "settings.yaml"
+    yaml_file.write_text(yaml_content)
+
+    with pytest.raises(SystemExit):
+        ServiceSettings.from_yaml(yaml_file)

--- a/tests/test_tls_transport.py
+++ b/tests/test_tls_transport.py
@@ -1,0 +1,258 @@
+"""Tests for TLS support in the socket factory and engine output sockets.
+
+Covers:
+  - NngPairSocketFactory: tls+tcp happy path and error cases
+  - Engine._setup_output_sockets: tls_config assignment ordering
+"""
+import socket
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pynng
+import pytest
+
+from service.features.engine import Engine
+from service.features.engine_socket import NngPairSocketFactory
+from service.settings import ServiceSettings, TlsInputConfig, TlsOutputConfig
+
+
+@pytest.fixture
+def mock_logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def socket_manager():
+    """Track and close pynng sockets after each test."""
+    sockets = []
+
+    def track(sock):
+        sockets.append(sock)
+        return sock
+
+    yield track
+
+    for sock in sockets:
+        try:
+            sock.close()
+        except pynng.NNGException:
+            pass
+
+
+@pytest.fixture
+def available_port():
+    """Return a free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def self_signed_cert(tmp_path):
+    """Generate a self-signed server cert+key PEM and CA cert using openssl.
+
+    The combined server PEM (cert + key in one file) is what pynng expects
+    for cert_key_file on the server side.
+
+    Returns a dict:
+        server_pem: Path  , combined cert + key (used as cert_key_file)
+        ca_pem:     Path  , CA cert (used as ca_file on client side)
+    """
+    ca_key = tmp_path / "ca.key"
+    ca_pem = tmp_path / "ca.pem"
+    server_key = tmp_path / "server.key"
+    server_csr = tmp_path / "server.csr"
+    server_crt = tmp_path / "server.crt"
+    server_pem = tmp_path / "server.pem"
+
+    subprocess.run(
+        ["openssl", "genrsa", "-out", str(ca_key), "2048"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "req", "-x509", "-new", "-nodes",
+         "-key", str(ca_key), "-days", "1", "-out", str(ca_pem),
+         "-subj", "/CN=DetectMate-Test-CA"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "genrsa", "-out", str(server_key), "2048"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "req", "-new",
+         "-key", str(server_key), "-out", str(server_csr),
+         "-subj", "/CN=127.0.0.1"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["openssl", "x509", "-req",
+         "-in", str(server_csr),
+         "-CA", str(ca_pem), "-CAkey", str(ca_key), "-CAcreateserial",
+         "-out", str(server_crt), "-days", "1"],
+        check=True, capture_output=True,
+    )
+    # pynng cert_key_file expects cert and key concatenated in one PEM file
+    server_pem.write_bytes(server_crt.read_bytes() + server_key.read_bytes())
+
+    return {"server_pem": server_pem, "ca_pem": ca_pem}
+
+
+@pytest.fixture
+def ipc_engine_addr(tmp_path):
+    """IPC address for the engine input socket used in engine output tests."""
+    return f"ipc://{tmp_path}/engine.ipc"
+
+
+# ---------------------------------------------------------------------------
+# NngPairSocketFactory, TLS error cases
+# ---------------------------------------------------------------------------
+
+def test_tls_tcp_no_tls_config_raises_value_error(available_port, mock_logger):
+    """Factory raises ValueError immediately when tls+tcp is used without a
+    config."""
+    factory = NngPairSocketFactory()
+    with pytest.raises(ValueError, match="tls_input"):
+        factory.create(f"tls+tcp://127.0.0.1:{available_port}", mock_logger)
+
+
+def test_tls_tcp_nonexistent_cert_raises(available_port, mock_logger):
+    """Factory raises an exception when the cert file path does not exist."""
+    tls_cfg = TlsInputConfig(cert_key_file=Path("/nonexistent/cert.pem"))
+    factory = NngPairSocketFactory()
+    with pytest.raises(Exception):  # pynng raises NNGException at TLSConfig or listen time
+        factory.create(
+            f"tls+tcp://127.0.0.1:{available_port}",
+            mock_logger,
+            tls_config=tls_cfg,
+        )
+
+
+# ---------------------------------------------------------------------------
+# NngPairSocketFactory,  TLS happy path
+# ---------------------------------------------------------------------------
+
+def test_tls_tcp_socket_creation(available_port, mock_logger, socket_manager, self_signed_cert):
+    """Factory creates a listening tls+tcp socket with a valid self-signed
+    cert."""
+    tls_cfg = TlsInputConfig(cert_key_file=self_signed_cert["server_pem"])
+    factory = NngPairSocketFactory()
+
+    sock = socket_manager(
+        factory.create(
+            f"tls+tcp://127.0.0.1:{available_port}",
+            mock_logger,
+            tls_config=tls_cfg,
+        )
+    )
+    assert sock is not None
+
+
+# ---------------------------------------------------------------------------
+# NngPairSocketFactory, TLS config assigned before listen()
+# ---------------------------------------------------------------------------
+
+def test_tls_config_assigned_before_listen(available_port, mock_logger, tmp_path):
+    """tls_config is set on the socket before listen() is called."""
+    cert = tmp_path / "fake.pem"
+    cert.touch()
+    tls_cfg = TlsInputConfig(cert_key_file=cert)
+    factory = NngPairSocketFactory()
+
+    tls_config_at_listen_time = []
+
+    with patch("service.features.engine_socket.pynng.Pair0") as MockPair0, \
+            patch("service.features.engine_socket.pynng.TLSConfig") as MockTLSConfig:
+
+        mock_sock = MagicMock()
+        MockPair0.return_value = mock_sock
+        mock_tls = MagicMock()
+        MockTLSConfig.return_value = mock_tls
+        MockTLSConfig.MODE_SERVER = pynng.TLSConfig.MODE_SERVER
+
+        def capture_on_listen(addr):
+            tls_config_at_listen_time.append(mock_sock.tls_config)
+
+        mock_sock.listen.side_effect = capture_on_listen
+
+        factory.create(
+            f"tls+tcp://127.0.0.1:{available_port}",
+            mock_logger,
+            tls_config=tls_cfg,
+        )
+
+    assert len(tls_config_at_listen_time) == 1, "listen() was not called exactly once"
+    assert tls_config_at_listen_time[0] is mock_tls, (
+        "tls_config was not assigned before listen()"
+    )
+
+
+def test_non_tls_socket_has_no_tls_config(available_port, mock_logger, tmp_path):
+    """Factory does not assign tls_config when creating a plain tcp socket."""
+    factory = NngPairSocketFactory()
+
+    with patch("service.features.engine_socket.pynng.Pair0") as MockPair0:
+        mock_sock = MagicMock()
+        MockPair0.return_value = mock_sock
+        mock_sock.tls_config = None  # start as None
+
+        def verify_no_tls_on_listen(addr):
+            pass  # don't actually listen
+
+        mock_sock.listen.side_effect = verify_no_tls_on_listen
+
+        factory.create(f"tcp://127.0.0.1:{available_port}", mock_logger)
+
+    assert mock_sock.tls_config is None, (
+        "tls_config should not be set for a plain tcp socket"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Engine._setup_output_sockets, TLS config assigned before dial()
+# ---------------------------------------------------------------------------
+
+def test_engine_output_tls_config_assigned_before_dial(tmp_path, ipc_engine_addr):
+    """Engine sets tls_config on the output socket before calling dial().
+
+    pynng requires tls_config to be assigned before dial() , the test
+    captures the value of tls_config at the moment dial() fires.
+    """
+    ca = tmp_path / "ca.pem"
+    ca.touch()
+    settings = ServiceSettings(
+        engine_addr=ipc_engine_addr,
+        http_host="127.0.0.1",
+        http_port=8097,
+        engine_autostart=False,
+        log_to_file=False,
+        out_addr=["tls+tcp://detector:15200"],
+        tls_output=TlsOutputConfig(ca_file=ca, server_name="detector"),
+    )
+
+    tls_config_at_dial = []
+    mock_out_sock = MagicMock()
+
+    def capture_on_dial(addr, block=True):
+        tls_config_at_dial.append(mock_out_sock.tls_config)
+
+    mock_out_sock.dial.side_effect = capture_on_dial
+
+    with patch("service.features.engine.pynng.Pair0", return_value=mock_out_sock), \
+            patch("service.features.engine.pynng.TLSConfig") as MockTLSConfig:
+        mock_tls = MagicMock()
+        MockTLSConfig.return_value = mock_tls
+        MockTLSConfig.MODE_CLIENT = pynng.TLSConfig.MODE_CLIENT
+
+        engine = Engine(
+            settings=settings,
+            processor=MagicMock(spec=["process"]),
+        )
+
+    assert len(tls_config_at_dial) == 1, "dial() was not called exactly once"
+    assert tls_config_at_dial[0] is mock_tls, (
+        "tls_config was not assigned before dial()"
+    )
+
+    engine._pair_sock.close()


### PR DESCRIPTION
# Task
#121 

# Description
settings.py
- Added TlsInputConfig model, cert_key_file: Path (server cert + key PEM)
- Added TlsOutputConfig model, ca_file: Path + optional server_name: str for SNI
- Added tls_input / tls_output optional fields to ServiceSettings
- Added @model_validator that raises a clear ValueError at startup if a tls+tcp:// address is present without the config block

engine_socket.py
- SocketFactorys create() gains tls_config: Optional[TlsInputConfig] parameter
- if tls+tcp: builds pynng.TLSConfig and assigns sock.tls_config before sock.listen()

engine.py
- _engine_socket_factory.create() call passes tls_config=self.settings.tls_input
- _setup_output_sockets() detects tls+tcp:// output addresses, builds pynng.TLSConfig and
assigns sock.tls_config 

# How Has This Been Tested?
TLS was verified with the existing Docker compose demo.
**create certificates:** (once, from the repo root):
```
mkdir -p container/certs
cd container/certs
# Self-signed CA
openssl genrsa -out ca.key 2048
openssl req -x509 -new -nodes -key ca.key -days 365 -out ca.pem -subj "/CN=DetectMate-Demo-CA"

# Server key and CSR, CN should match the Docker service name "detector"
openssl genrsa -out server.key 2048
openssl req -new -key server.key -out server.csr -subj "/CN=detector"

# Sign server cert with the CA
openssl x509 -req -in server.csr -CA ca.pem -CAkey ca.key -CAcreateserial -out server.crt -days 365

# Combine cert + key into one PEM file (required by pynng)
cat server.crt server.key > server.pem

# Remove intermediate files
 rm ca.key ca.srl server.key server.csr server.crt
```

**run docker compose with override for the tls settings:**  
`docker compose -f docker-compose.yml -f docker-compose.tls.yml up --build`

**with the following files:**
container/config/parser_settings_tls.yaml

```
component_name: accesslogparser
component_type: MatcherParser
log_level: "DEBUG"
log_dir: "/logs"
http_host: 0.0.0.0
engine_addr: "ipc:///run/parser.engine.ipc"
engine_autostart: true
out_addr:
  - "tls+tcp://detector:5555"
tls_output:
  ca_file: /certs/ca.pem
  server_name: "detector"
out_dial_timeout: 1000
```

container/config/detector_settings_tls.yaml
```
component_name: NewValueDetector01
component_type: NewValueDetector
log_level: "DEBUG"
log_dir: "/logs"
http_host: 0.0.0.0
engine_addr: "tls+tcp://0.0.0.0:5555"
engine_autostart: true
tls_input:
  cert_key_file: /certs/server.pem
out_addr:
  - "ipc:///run/output.ipc"
out_dial_timeout: 1000
```

 docker-compose.tls.yml
```
services:

  parser:
    volumes:
      - '$PWD/container/certs:/certs:ro'
    command: uv run detectmate --settings /config/parser_settings_tls.yaml --config /config/parser_config.yaml

  detector:
    volumes:
      - '$PWD/container/certs:/certs:ro'
    command: uv run detectmate --settings /config/detector_settings_tls.yaml --config /config/detector_config.yaml
    ports:
      - "5555:5555"
```





# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
