### PR TITLE
Update CLI to only start DetectMate with a defined settings path.

### DIFF
--- a/src/service/cli.py
+++ b/src/service/cli.py
@@ -44,7 +44,9 @@ def main() -> None:
     if args.settings and args.settings.exists():
         settings = ServiceSettings.from_yaml(args.settings)
     else:
-        settings = ServiceSettings()
+        logger.error("Settings path must be defined.")
+        parser.print_help()
+        sys.exit(1)
 
     if args.config:
         settings.config_file = args.config


### PR DESCRIPTION
# Task
Fixes #157 

# Description
Shows help output and error log when no settings path is defined.

# How Has This Been Tested?
```
uv run detectmate
[2026-06-09 08:43:40,303] ERROR service.cli: Settings path must be defined.
[2026-06-09 08:43:40,303] ERROR service.cli: Settings path must be defined.
usage: detectmate [-h] [--settings SETTINGS] [--config CONFIG]

DetectMate Service Launcher

options:
  -h, --help           show this help message and exit
  --settings SETTINGS  Path to service settings YAML
  --config CONFIG      Path to component config YAML
ernst@ernst-VirtualBox:~/Documents/DetectMateService$ uv run detectmate --settings examples/service_settings.yaml 
[2026-06-09 08:43:44,146] INFO service.cli: config file: None
[2026-06-09 08:43:44,146] INFO service.cli: config file: None
[2026-06-09 08:43:44,149] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Loading library component: detectors.RandomDetector
[2026-06-09 08:43:44,149] DEBUG detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Importing module 'detectors', class 'RandomDetector'
[2026-06-09 08:43:44,149] DEBUG detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Direct import failed, retrying as 'detectmatelibrary.detectors'
[2026-06-09 08:43:44,150] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Successfully loaded component: <detectors> RandomDetector: method_type='random_detector' component_type='detectors' auto_config=True start_id=10 data_use_training=None data_use_configure=None parser='<PLACEHOLDER>' events={} global_instances={}
[2026-06-09 08:43:44,151] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Initialized output socket for tcp://127.0.0.1:5000 (background connect)
[2026-06-09 08:43:44,152] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Initialized output socket for ipc:///tmp/output.ipc (background connect)
[2026-06-09 08:43:44,152] DEBUG detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Engine initialized and ready.
[2026-06-09 08:43:44,152] DEBUG detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: detectors.RandomDetector[f07f2ba3d1d8564397e53a42e328ab12] created and fully initialized
[2026-06-09 08:43:44,152] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: setup_io: ready to process messages
[2026-06-09 08:43:44,153] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: HTTP Admin active at 127.0.0.1:8000
[2026-06-09 08:43:44,153] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: Auto-starting engine...
[2026-06-09 08:43:44,180] INFO detectors.RandomDetector.f07f2ba3d1d8564397e53a42e328ab12: engine started
INFO:     Started server process [33630]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
```


# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.