### PR TITLE
Excluded integrations-tests

### DIFF
--- a/pytest.toml
+++ b/pytest.toml
@@ -1,0 +1,2 @@
+[pytest]
+norecursedirs = ["library_integration"]


### PR DESCRIPTION
Integrationtests are currently broken. This commit excludes the integrationtests from pytest-runs. A new framework for testing the integrationtests is highly needed.

# Task

This task is a workaround for #168 

# Description

I removed the integrationtests.

# How Has This Been Tested?

I ran pytest

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [ ] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
