### PR TITLE
Feature/no autostart cli parameter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,8 @@
 # Configuration
 
-DetectMateService can be configured using a YAML settings file or environment variables. Environment variables take precedence over the YAML file.
+DetectMateService can be configured using a YAML settings file, environment variables, or CLI flags. The precedence order is:
+
+**CLI flags > environment variables > YAML file**
 
 ## Service settings
 
@@ -21,7 +23,7 @@ These settings control the service infrastructure.
 | `manager_recv_timeout`        | `DETECTMATE_MANAGER_RECV_TIMEOUT`        | `100`                              | Receive timeout (ms) for the manager command channel.                                                     |
 | `manager_thread_join_timeout` | `DETECTMATE_MANAGER_THREAD_JOIN_TIMEOUT` | `1.0`                              | Timeout (s) when waiting for the manager thread to stop.                                                  |
 | `engine_addr`                 | `DETECTMATE_ENGINE_ADDR`                 | `ipc:///tmp/detectmate.engine.ipc` | Address for data processing (PAIR0/1).                                                                    |
-| `engine_autostart`            | `DETECTMATE_ENGINE_AUTOSTART`            | `true`                             | Whether the engine channel is started automatically.                                                      |
+| `engine_autostart`            | `DETECTMATE_ENGINE_AUTOSTART`            | `true`                             | Whether the engine starts automatically on launch. Can also be overridden at runtime with `--no-autostart`. |
 | `engine_recv_timeout`         | `DETECTMATE_ENGINE_RECV_TIMEOUT`         | `100`                              | Receive timeout (ms) for the engine channel.                                                              |
 | `engine_retry_count`         | `DETECTMATE_ENGINE_RETRY_COUNT`          | `10`                               | Retry count for resending messages when TryAgain exception occurs.                                        |
 | `engine_buffer_size`         | `DETECTMATE_ENGINE_BUFFER_SIZE`          | `100`                              | Buffer size for the number of sent and received messages in NNG.                                          |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,8 +48,29 @@ To start the service, use the `detectmate` command. You can optionally specify a
 detectmate --settings settings.yaml --config config.yaml
 ```
 
-- `--settings`: Path to the service settings YAML file.
-- `--config`: Path to the component configuration YAML file.
+| Flag | Description |
+| :--- | :--- |
+| `--settings` | Path to the service settings YAML file. |
+| `--config` | Path to the component configuration YAML file. |
+| `--no-autostart` | Start the service without auto-starting the engine. Use `POST /admin/start` to begin processing. |
+
+## Starting in standby mode
+
+By default the engine starts automatically when the service launches. Pass `--no-autostart` to keep the engine idle on startup:
+
+```bash
+detectmate --settings settings.yaml --no-autostart
+```
+
+The HTTP Admin API is fully available immediately. The engine stays idle until you trigger it explicitly:
+
+```bash
+curl -X POST http://127.0.0.1:8000/admin/start
+```
+
+This is useful for staged startup workflows where you want to validate configuration or wait for upstream/downstream peers to be ready before allowing data to flow.
+
+The same behaviour can also be configured persistently via the settings file or environment variable - see [`engine_autostart`](configuration.md#service-settings).
 
 ## Checking status
 

--- a/src/service/cli.py
+++ b/src/service/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 from .settings import ServiceSettings
 from .core import Service
@@ -37,6 +38,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="DetectMate Service Launcher")
     parser.add_argument("--settings", type=Path, help="Path to service settings YAML")
     parser.add_argument("--config", type=Path, help="Path to component config YAML")
+    parser.add_argument(
+        "--no-autostart",
+        action="store_true",
+        help="Start the service without auto-starting the engine. "
+             "Use POST /admin/start to begin processing.",
+    )
 
     args = parser.parse_args()
 
@@ -48,11 +55,13 @@ def main() -> None:
         parser.print_help()
         sys.exit(1)
 
+    overrides: dict[str, Any] = {}
+    if args.no_autostart:
+        overrides["engine_autostart"] = False
     if args.config:
-        settings.config_file = args.config
+        overrides["config_file"] = args.config
+    settings = settings.model_copy(update=overrides)
     logger.info("config file: %s", settings.config_file)
-    # Initialize and run
-    # Note: Service now inherits from Service, not CLIService
     service = Service(settings=settings)
 
     try:

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -2,7 +2,6 @@ import logging
 import sys
 import yaml
 import pytest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from service.cli import main
@@ -48,7 +47,8 @@ def run_main(argv: list[str]) -> ServiceSettings:
         main()
 
     assert mock_service.called, "Service() was never instantiated — main() exited early"
-    return mock_service.call_args[0][0] if mock_service.call_args[0] else mock_service.call_args[1]["settings"]
+    args, kwargs = mock_service.call_args
+    return args[0] if args else kwargs["settings"]
 
 
 def test_no_autostart_flag_overrides_yaml(settings_yaml):

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,111 @@
+import logging
+import sys
+import yaml
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from service.cli import main
+from service.settings import ServiceSettings
+
+
+@pytest.fixture(autouse=True)
+def reset_root_logger():
+    """Restore root logger handlers after each test.
+
+    main() calls setup_logging() which unconditionally appends handlers;
+    without cleanup they accumulate across tests in this session.
+    """
+    original_handlers = logging.root.handlers[:]
+    original_level = logging.root.level
+    yield
+    logging.root.handlers = original_handlers
+    logging.root.setLevel(original_level)
+
+
+@pytest.fixture
+def settings_yaml(tmp_path):
+    """Write a minimal settings YAML and return its path."""
+    data = {
+        "component_type": "core",
+        "engine_addr": f"ipc://{tmp_path}/test.ipc",
+        "log_to_file": False,
+        "engine_autostart": True,
+    }
+    path = tmp_path / "settings.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+def run_main(argv: list[str]) -> ServiceSettings:
+    """Run main() with the given argv and return the ServiceSettings that
+    Service was instantiated with."""
+    mock_service = MagicMock()
+    mock_service.return_value.__enter__ = MagicMock(return_value=mock_service.return_value)
+    mock_service.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch.object(sys, "argv", argv), patch("service.cli.Service", mock_service):
+        main()
+
+    assert mock_service.called, "Service() was never instantiated — main() exited early"
+    return mock_service.call_args[0][0] if mock_service.call_args[0] else mock_service.call_args[1]["settings"]
+
+
+def test_no_autostart_flag_overrides_yaml(settings_yaml):
+    """--no-autostart sets engine_autostart=False even when YAML says True."""
+    settings = run_main(["detectmate-service", "--settings", str(settings_yaml), "--no-autostart"])
+    assert settings.engine_autostart is False
+
+
+def test_without_no_autostart_yaml_value_is_kept(settings_yaml):
+    """Without --no-autostart the YAML value (True) is preserved."""
+    settings = run_main(["detectmate-service", "--settings", str(settings_yaml)])
+    assert settings.engine_autostart is True
+
+
+def test_no_autostart_uses_model_copy_not_mutation(settings_yaml):
+    """--no-autostart creates a new settings object via model_copy, not direct mutation."""
+    original = ServiceSettings.from_yaml(settings_yaml)
+
+    with patch("service.cli.ServiceSettings.from_yaml", return_value=original):
+        settings = run_main(["detectmate-service", "--settings", str(settings_yaml), "--no-autostart"])
+
+    assert settings is not original, "model_copy must produce a new object, not mutate in place"
+    assert original.engine_autostart is True, "original settings must not be mutated"
+    assert settings.engine_autostart is False
+
+
+def test_config_flag_sets_config_file(settings_yaml, tmp_path):
+    """--config sets config_file on the settings passed to Service."""
+    config_file = tmp_path / "component.yaml"
+    config_file.write_text("{}")
+
+    settings = run_main([
+        "detectmate-service",
+        "--settings", str(settings_yaml),
+        "--config", str(config_file),
+    ])
+    assert settings.config_file == config_file
+
+
+def test_no_autostart_and_config_combined(settings_yaml, tmp_path):
+    """Both --no-autostart and --config apply in the same model_copy call."""
+    config_file = tmp_path / "component.yaml"
+    config_file.write_text("{}")
+
+    settings = run_main([
+        "detectmate-service",
+        "--settings", str(settings_yaml),
+        "--no-autostart",
+        "--config", str(config_file),
+    ])
+    assert settings.engine_autostart is False
+    assert settings.config_file == config_file
+
+
+def test_missing_settings_exits(tmp_path):
+    """Pointing --settings at a non-existent file causes sys.exit(1)."""
+    with patch.object(sys, "argv", ["detectmate-service", "--settings", str(tmp_path / "missing.yaml")]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    assert exc_info.value.code == 1


### PR DESCRIPTION
# Task
#182 
 in the settings

# Description
- Add `--no-autostart` argument to the service CLI that starts the service with the engine idle, requiring  explicit `POST /admin/start` to begin processing
-  Apply all CLI overrides via `model_copy` instead of direct field mutation on the settings object
- Add unit tests 


# How Has This Been Tested?
new unit tests.

manually: start with --no autostart
<img width="1568" height="371" alt="image" src="https://github.com/user-attachments/assets/f99e34e6-7c47-4be1-8866-44814e006ad4" />

then send curl -X POST http://127.0.0.1:8000/admin/start

<img width="1434" height="414" alt="image" src="https://github.com/user-attachments/assets/aebc9e20-9f27-4ad2-b68d-832341829b42" />



starting normally: 
<img width="1568" height="371" alt="image" src="https://github.com/user-attachments/assets/80963ce4-c1d7-4666-95a0-08227b7e6865" />



examples/service_settings.yaml:
```
component_name: random-detector
component_type: detectors.RandomDetector
component_config_class: detectors.RandomDetectorConfig
log_level: "DEBUG"
log_dir: "./logs"

# Manager Interface (Command Channel)
manager_addr: "ipc:///tmp/detectmate.cmd.ipc"

# Engine Interface (Data Channel)
engine_addr: "ipc:///tmp/detectmate.engine.ipc"
engine_autostart: true

# Output Destinations (where processed data is sent)
out_addr:
  - "tcp://127.0.0.1:5000"
  - "ipc:///tmp/output.ipc"

out_dial_timeout: 1000
```




# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
