### PR TITLE
fall back to settings.component_type instead of being left unset

### DIFF
--- a/src/service/core.py
+++ b/src/service/core.py
@@ -107,6 +107,9 @@ class Service(Engine, ABC):
             if not settings.component_config_class:
                 settings.component_config_class = resolved_config
 
+        if not hasattr(self, 'component_type'):
+            self.component_type = settings.component_type
+
         # Initialize config manager before loading the library component
         # so we can pass the loaded configs to the component
         self.config_manager: Optional[ConfigManager] = None

--- a/tests/test_smoke_service.py
+++ b/tests/test_smoke_service.py
@@ -115,3 +115,17 @@ def test_service_id_stability():
     )
 
     assert settings1.component_id != settings3.component_id
+
+
+def test_core_service_instantiation(tmp_path, free_port):
+    """Service with component_type=core must not raise AttributeError on
+    init."""
+    settings = ServiceSettings(
+        component_type="core",
+        engine_addr=f"ipc://{tmp_path}/core_test.ipc",
+        http_port=free_port,
+        log_level="ERROR",
+    )
+    service = Service(settings=settings)
+    assert service.component_type == "core"
+    service.stop()


### PR DESCRIPTION
# Task
#158 

# Description
Fixes AttributeError: 'Service' object has no attribute 'component_type' when running detectmate with component_type: core in settings. 
The core case was intentionally skipped by the resolver block but never set self.component_type as a fallback


# How Has This Been Tested?
<img width="1061" height="426" alt="image" src="https://github.com/user-attachments/assets/22e9d7b5-e27a-4f95-a8e6-ad522d56b787" />
# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [x] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
