### PR TITLE
improve github actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,7 +41,6 @@ jobs:
     # fallback (lockfile hash only) still lets a *new* library commit reuse
     # the cached stable dependencies and only fetch/build what changed
     - name: Cache uv dependencies
-      id: cache-uv
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.cache/uv
@@ -58,16 +57,6 @@ jobs:
         activate-environment: true
         enable-cache: false
         cache-local-path: ${{ github.workspace }}/.cache/uv
-
-    # TEMPORARY: remove once caching bug is fixed
-    - name: Debug uv cache
-      run: |
-        echo "restore step outputs: cache-hit=${{ steps.cache-uv.outputs.cache-hit }}"
-        echo "UV_CACHE_DIR=$UV_CACHE_DIR"
-        echo "expected path=${{ github.workspace }}/.cache/uv"
-        ls -la "$UV_CACHE_DIR" 2>&1 | head -20
-        du -sh "$UV_CACHE_DIR" 2>&1 || true
-        uv cache dir
 
     - name: Run pre-commit with prek
       run: uv run --dev prek run -a

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,6 +22,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Pinned explicitly rather than left to setup-uv's default so the "Cache
+    # uv dependencies" step below is guaranteed to cache the same directory
+    # uv actually writes to.
+    env:
+      UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
+
     steps:
     - uses: actions/checkout@v4
 
@@ -37,7 +43,7 @@ jobs:
     - name: Cache uv dependencies
       uses: actions/cache@v4
       with:
-        path: ~/.cache/uv
+        path: ${{ github.workspace }}/.cache/uv
         key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}-${{ steps.pin_library.outputs.library_sha }}
         restore-keys: |
           ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}-

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -59,4 +59,4 @@ jobs:
       run: uv run --dev prek run -a
         
     - name: Test with pytest
-      run: uv run --dev pytest -s
+      run: uv run --dev pytest -s -n auto

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,8 @@ jobs:
 
     # Keyed on the resolved DetectMateLibrary commit (see change_toml.sh) so a
     # rerun or another PR against the same library commit gets a full cache
-    # hit instead of re-cloning/re-resolving/rebuilding it. The restore-keys
+    # hit instead of re-cloning/re-resolving/rebuilding it
+    # The restore-keys
     # fallback (lockfile hash only) still lets a *new* library commit reuse
     # the cached stable dependencies and only fetch/build what changed
     - name: Cache uv dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -41,6 +41,7 @@ jobs:
     # fallback (lockfile hash only) still lets a *new* library commit reuse
     # the cached stable dependencies and only fetch/build what changed
     - name: Cache uv dependencies
+      id: cache-uv
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.cache/uv
@@ -54,6 +55,16 @@ jobs:
         python-version: "3.12"
         activate-environment: true
         enable-cache: false
+
+    # TEMPORARY: remove once caching bug is fixed
+    - name: Debug uv cache
+      run: |
+        echo "restore step outputs: cache-hit=${{ steps.cache-uv.outputs.cache-hit }}"
+        echo "UV_CACHE_DIR=$UV_CACHE_DIR"
+        echo "expected path=${{ github.workspace }}/.cache/uv"
+        ls -la "$UV_CACHE_DIR" 2>&1 | head -20
+        du -sh "$UV_CACHE_DIR" 2>&1 || true
+        uv cache dir
 
     - name: Run pre-commit with prek
       run: uv run --dev prek run -a

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,8 +32,7 @@ jobs:
     # Keyed on the resolved DetectMateLibrary commit (see change_toml.sh) so a
     # rerun or another PR against the same library commit gets a full cache
     # hit instead of re-cloning/re-resolving/rebuilding it
-    # The restore-keys
-    # fallback (lockfile hash only) still lets a *new* library commit reuse
+    # The restore-keysfallback (lockfile hash only) still lets a *new* library commit reuse
     # the cached stable dependencies and only fetch/build what changed
     - name: Cache uv dependencies
       uses: actions/cache@v4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,7 @@ jobs:
     # rerun or another PR against the same library commit gets a full cache
     # hit instead of re-cloning/re-resolving/rebuilding it. The restore-keys
     # fallback (lockfile hash only) still lets a *new* library commit reuse
-    # the cached stable dependencies and only fetch/build what changed.
+    # the cached stable dependencies and only fetch/build what changed
     - name: Cache uv dependencies
       uses: actions/cache@v4
       with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,15 +21,29 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Use specific detematelibrary version
+      id: pin_library
+      run: chmod +x scripts/change_toml.sh && scripts/change_toml.sh $GITHUB_BASE_REF
+
+    # Keyed on the resolved DetectMateLibrary commit (see change_toml.sh) so a
+    # rerun or another PR against the same library commit gets a full cache
+    # hit instead of re-cloning/re-resolving/rebuilding it. The restore-keys
+    # fallback (lockfile hash only) still lets a *new* library commit reuse
+    # the cached stable dependencies and only fetch/build what changed.
+    - name: Cache uv dependencies
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}-${{ steps.pin_library.outputs.library_sha }}
+        restore-keys: |
+          ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}-
+
     - name: Set up uv (Python 3.12)
       uses: astral-sh/setup-uv@v6.6.0
       with:
         python-version: "3.12"
         activate-environment: true
-        enable-cache: true
-
-    - name: Use specific detematelibrary version
-      run: chmod +x scripts/change_toml.sh && scripts/change_toml.sh $GITHUB_BASE_REF
+        enable-cache: false
 
     - name: Run pre-commit with prek
       run: uv run --dev prek run -a

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,12 +22,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # Pinned explicitly rather than left to setup-uv's default so the "Cache
-    # uv dependencies" step below is guaranteed to cache the same directory
-    # uv actually writes to.
-    env:
-      UV_CACHE_DIR: ${{ github.workspace }}/.cache/uv
-
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -59,4 +59,4 @@ jobs:
       run: uv run --dev prek run -a
         
     - name: Test with pytest
-      run: uv run --dev pytest -s -n auto
+      run: uv run --dev pytest -s -n 4

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -49,12 +49,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}-
 
+    # cache-local-path is set explicitly because setup-uv otherwise
+    # overrides UV_CACHE_DIR to an ephemeral per-job temp dir 
     - name: Set up uv (Python 3.12)
       uses: astral-sh/setup-uv@v6.6.0
       with:
         python-version: "3.12"
         activate-environment: true
         enable-cache: false
+        cache-local-path: ${{ github.workspace }}/.cache/uv
 
     # TEMPORARY: remove once caching bug is fixed
     - name: Debug uv cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest>=9.1.0",
     "prek>=0.4.8",
     "pytest-cov>=6.2.1",
+    "pytest-xdist>=3.8.0",
     "types-requests",
     "httpx2>=2.7.0",
     "DetectMateService[full]",

--- a/scripts/change_toml.sh
+++ b/scripts/change_toml.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
+set -e
 
-REPLACE=DetectMateLibrary.git
+REPO_URL=https://github.com/ait-detectmate/DetectMateLibrary.git
 
 if [ $# -eq 0 ]
 then
@@ -17,5 +18,24 @@ fi
 
 echo "Using branch: $BRANCH"
 
-GIT_SOURCE="git+https://github.com/ait-detectmate/DetectMateLibrary.git@${BRANCH}"
+# Resolve to a commit SHA instead of pinning the git dependency to the
+# branch name. This gives CI caching (uv's own cache and the workflow's
+# actions/cache step) a stable key to work with: reruns against the same
+# library commit hit cache instead of re-cloning/re-resolving every time.
+SHA=$(git ls-remote "$REPO_URL" "refs/heads/${BRANCH}" | cut -f1)
+
+if [ -z "$SHA" ]
+then
+	echo "Could not resolve branch '${BRANCH}' on ${REPO_URL}" >&2
+	exit 1
+fi
+
+echo "Resolved ${BRANCH} to ${SHA}"
+
+GIT_SOURCE="git+${REPO_URL}@${SHA}"
 sed -i -E "s|detectmatelibrary==[^\"]+|detectmatelibrary @ ${GIT_SOURCE}|g" pyproject.toml
+
+if [ -n "$GITHUB_OUTPUT" ]
+then
+	echo "library_sha=${SHA}" >> "$GITHUB_OUTPUT"
+fi

--- a/tests/library_integration/library_integration_base.py
+++ b/tests/library_integration/library_integration_base.py
@@ -1,12 +1,24 @@
 import time
 import json
 import signal
+import socket
 import yaml
 import sys
 from subprocess import Popen, PIPE, TimeoutExpired
 
 
 AUDIT_LOG = "tests/library_integration/audit.log"
+
+
+def free_port() -> str:
+    """Return an OS-assigned free TCP port on localhost.
+
+    Used instead of hardcoded ports so parallel test workers (pytest-
+    xdist) don't race to bind the same port.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return str(s.getsockname()[1])
 
 
 def start_service(module_path, settings, config, settings_file, config_file):

--- a/tests/library_integration/test_detector_integration.py
+++ b/tests/library_integration/test_detector_integration.py
@@ -96,8 +96,8 @@ class TestDetectorServiceViaEngine:
         engine_addr = running_detector_service["engine_addr"]
         results = []
 
-        for i, parser_message in enumerate(test_parser_messages):
-            with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+        with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+            for i, parser_message in enumerate(test_parser_messages):
                 socket.send(parser_message)
 
                 try:
@@ -130,8 +130,7 @@ class TestDetectorServiceViaEngine:
             except pynng.Timeout:
                 pass  # Expected
 
-        # Second message WILL trigger detection
-        with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+            # Second message WILL trigger detection
             socket.send(test_parser_messages[1])
 
             try:
@@ -169,8 +168,8 @@ class TestDetectorServiceViaEngine:
         detection_count = 0
         no_detection_count = 0
 
-        for i, parser_message in enumerate(test_parser_messages):
-            with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+        with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+            for i, parser_message in enumerate(test_parser_messages):
                 socket.send(parser_message)
 
                 try:
@@ -199,8 +198,8 @@ class TestDetectorServiceViaEngine:
 
         # Try all messages and collect scores from successful detections
         scores = []
-        for parser_message in test_parser_messages:
-            with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+        with pynng.Pair0(dial=engine_addr, recv_timeout=2000) as socket:
+            for parser_message in test_parser_messages:
                 socket.send(parser_message)
                 try:
                     response = socket.recv()

--- a/tests/library_integration/test_detector_integration.py
+++ b/tests/library_integration/test_detector_integration.py
@@ -5,7 +5,7 @@ Timeout means no detection occurred (detector returns None/False).
 DummyDetector alternates: False, True, False
 """
 from library_integration_base import start_service, cleanup_service, free_port
-import time
+import uuid
 from pathlib import Path
 from typing import Generator
 import pytest
@@ -19,7 +19,7 @@ pytest_plugins = ["library_integration_base_fixtures"]
 def running_detector_service(tmp_path: Path) -> Generator[dict, None, None]:
     """Start the detector service with test config and yield connection
     info."""
-    timestamp = int(time.time() * 1000)
+    unique_id = uuid.uuid4().hex
     module_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     settings = {
         "component_type": "detectmatelibrary._testutils.dummy_detector.DummyDetector",
@@ -27,7 +27,7 @@ def running_detector_service(tmp_path: Path) -> Generator[dict, None, None]:
         "component_name": "test-detector",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_detector_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_detector_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": False,

--- a/tests/library_integration/test_detector_integration.py
+++ b/tests/library_integration/test_detector_integration.py
@@ -4,7 +4,7 @@ Tests verify detection via engine socket with ParserSchema input.
 Timeout means no detection occurred (detector returns None/False).
 DummyDetector alternates: False, True, False
 """
-from library_integration_base import start_service, cleanup_service
+from library_integration_base import start_service, cleanup_service, free_port
 import time
 from pathlib import Path
 from typing import Generator
@@ -26,7 +26,7 @@ def running_detector_service(tmp_path: Path) -> Generator[dict, None, None]:
         "component_config_class": "detectmatelibrary._testutils.dummy_detector.DummyDetectorConfig",
         "component_name": "test-detector",
         "http_host": "127.0.0.1",
-        "http_port": "8010",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_detector_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",

--- a/tests/library_integration/test_one_pipe_to_rule_them_all.py
+++ b/tests/library_integration/test_one_pipe_to_rule_them_all.py
@@ -16,6 +16,7 @@ import pytest
 from typing import Generator
 from pathlib import Path
 import time
+import uuid
 from library_integration_base import start_service, cleanup_service, free_port, AUDIT_LOG
 from detectmatelibrary._testutils.dummy_parser import DummyParser
 import os
@@ -28,7 +29,7 @@ pytest_plugins = ["library_integration_base_fixtures"]
 def running_pipeline_services(tmp_path: Path, test_templates_file: Path) -> Generator[dict, None, None]:
     """Start all three services (Reader, Parser, Detector) with test
     configs."""
-    timestamp = int(time.time() * 1000)
+    unique_id = uuid.uuid4().hex
     module_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     # Parser settings
@@ -38,7 +39,7 @@ def running_pipeline_services(tmp_path: Path, test_templates_file: Path) -> Gene
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": False,
@@ -64,7 +65,7 @@ def running_pipeline_services(tmp_path: Path, test_templates_file: Path) -> Gene
         "component_name": "test-detector",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": False,

--- a/tests/library_integration/test_one_pipe_to_rule_them_all.py
+++ b/tests/library_integration/test_one_pipe_to_rule_them_all.py
@@ -16,7 +16,7 @@ import pytest
 from typing import Generator
 from pathlib import Path
 import time
-from library_integration_base import start_service, cleanup_service, AUDIT_LOG
+from library_integration_base import start_service, cleanup_service, free_port, AUDIT_LOG
 from detectmatelibrary._testutils.dummy_parser import DummyParser
 import os
 import sys
@@ -37,7 +37,7 @@ def running_pipeline_services(tmp_path: Path, test_templates_file: Path) -> Gene
         "component_config_class": "detectmatelibrary._testutils.dummy_parser.DummyParserConfig",
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
-        "http_port": "8020",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
@@ -63,7 +63,7 @@ def running_pipeline_services(tmp_path: Path, test_templates_file: Path) -> Gene
         "component_config_class": "detectmatelibrary._testutils.dummy_detector.DummyDetectorConfig",
         "component_name": "test-detector",
         "http_host": "127.0.0.1",
-        "http_port": "8030",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",

--- a/tests/library_integration/test_one_pipe_to_rule_them_all.py
+++ b/tests/library_integration/test_one_pipe_to_rule_them_all.py
@@ -175,27 +175,27 @@ class TestFullPipeline:
 
         detection_results: list[bool] = []
 
-        for iteration in range(3):
-            # Step 1: Read log
-            parser = DummyParser(config=running_pipeline_services["parser_config"])
-            logs = [log for log in From.log(parser, AUDIT_LOG, do_process=True) if log is not None]
-            log_schema = logs[0]
-            assert hasattr(log_schema, "log")
-            assert hasattr(log_schema, "logID")
+        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as parser_socket, \
+                pynng.Pair0(dial=detector_engine, recv_timeout=2000) as detector_socket:
+            for iteration in range(3):
+                # Step 1: Read log
+                parser = DummyParser(config=running_pipeline_services["parser_config"])
+                logs = [log for log in From.log(parser, AUDIT_LOG, do_process=True) if log is not None]
+                log_schema = logs[0]
+                assert hasattr(log_schema, "log")
+                assert hasattr(log_schema, "logID")
 
-            # Step 2: Parse log
-            with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as socket:
-                socket.send(log_schema.serialize())
-                parser_response = socket.recv()
+                # Step 2: Parse log
+                parser_socket.send(log_schema.serialize())
+                parser_response = parser_socket.recv()
 
-            parser_schema = ParserSchema()
-            parser_schema.deserialize(parser_response)
+                parser_schema = ParserSchema()
+                parser_schema.deserialize(parser_response)
 
-            # Step 3: Detect
-            with pynng.Pair0(dial=detector_engine, recv_timeout=2000) as socket:
-                socket.send(parser_schema.serialize())
+                # Step 3: Detect
+                detector_socket.send(parser_schema.serialize())
                 try:
-                    detector_response = socket.recv()
+                    detector_response = detector_socket.recv()
                     detector_schema = DetectorSchema()
                     detector_schema.deserialize(detector_response)
 
@@ -251,35 +251,33 @@ class TestFullPipeline:
         assert hasattr(log_schema, "log")
         assert hasattr(log_schema, "logID")
 
-        # Parse
-        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as socket:
-            socket.send(log_schema.serialize())
-            parser_response = socket.recv()
+        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as parser_socket, \
+                pynng.Pair0(dial=detector_engine, recv_timeout=2000) as detector_socket:
+            # Parse
+            parser_socket.send(log_schema.serialize())
+            parser_response = parser_socket.recv()
 
-        parser_schema = ParserSchema()
-        parser_schema.deserialize(parser_response)
+            parser_schema = ParserSchema()
+            parser_schema.deserialize(parser_response)
 
-        # Detect
-        with pynng.Pair0(dial=detector_engine, recv_timeout=2000) as socket:
-            socket.send(parser_schema.serialize())
+            # Detect
+            detector_socket.send(parser_schema.serialize())
             try:
-                socket.recv()
+                detector_socket.recv()
             except pynng.Timeout:
                 pass  # Expected (no detection for first flow)
 
-        # Second flow: WITH detection (True)
-        log_schema_2 = logs[1]
+            # Second flow: WITH detection (True)
+            log_schema_2 = logs[1]
 
-        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as socket:
-            socket.send(log_schema_2.serialize())
-            parser_response_2 = socket.recv()
+            parser_socket.send(log_schema_2.serialize())
+            parser_response_2 = parser_socket.recv()
 
-        parser_schema_2 = ParserSchema()
-        parser_schema_2.deserialize(parser_response_2)
+            parser_schema_2 = ParserSchema()
+            parser_schema_2.deserialize(parser_response_2)
 
-        with pynng.Pair0(dial=detector_engine, recv_timeout=2000) as socket:
-            socket.send(parser_schema_2.serialize())
-            detector_response = socket.recv()
+            detector_socket.send(parser_schema_2.serialize())
+            detector_response = detector_socket.recv()
 
         # Verify detection occurred
         detector_schema = DetectorSchema()
@@ -304,31 +302,31 @@ class TestFullPipeline:
         # Read
         parser = DummyParser(config=running_pipeline_services["parser_config"])
         logs = [log for log in From.log(parser, AUDIT_LOG, do_process=True) if log is not None]
-        for i in range(3):
-            log_schema = logs[i]
-            assert hasattr(log_schema, "log")
-            assert hasattr(log_schema, "logID")
+        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as parser_socket, \
+                pynng.Pair0(dial=detector_engine, recv_timeout=2000) as detector_socket:
+            for i in range(3):
+                log_schema = logs[i]
+                assert hasattr(log_schema, "log")
+                assert hasattr(log_schema, "logID")
 
-            # Parse
-            with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as socket:
-                socket.send(log_schema.serialize())
-                parser_response = socket.recv()
+                # Parse
+                parser_socket.send(log_schema.serialize())
+                parser_response = parser_socket.recv()
 
-            parser_schema = ParserSchema()
-            parser_schema.deserialize(parser_response)
+                parser_schema = ParserSchema()
+                parser_schema.deserialize(parser_response)
 
-            processed_logs.append({
-                "original_log": log_schema.log,
-                "parsed_log": parser_schema.log,
-                "logID": log_schema.logID,
-            })
+                processed_logs.append({
+                    "original_log": log_schema.log,
+                    "parsed_log": parser_schema.log,
+                    "logID": log_schema.logID,
+                })
 
-            # Detect
-            with pynng.Pair0(dial=detector_engine, recv_timeout=2000) as socket:
-                socket.send(parser_schema.serialize())
+                # Detect
+                detector_socket.send(parser_schema.serialize())
                 try:
                     # we only care if a detection response was produced
-                    socket.recv()
+                    detector_socket.recv()
                     detection_count += 1
                 except pynng.Timeout:
                     pass  # No detection

--- a/tests/library_integration/test_parser_integration.py
+++ b/tests/library_integration/test_parser_integration.py
@@ -2,7 +2,7 @@
 
 Tests verify parsing via engine socket with LogSchema input.
 """
-from library_integration_base import start_service, cleanup_service
+from library_integration_base import start_service, cleanup_service, free_port
 import time
 from pathlib import Path
 from typing import Generator
@@ -23,7 +23,7 @@ def running_parser_service(tmp_path: Path) -> Generator[dict, None, None]:
         "component_config_class": "detectmatelibrary._testutils.dummy_parser.DummyParserConfig",
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
-        "http_port": "8020",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_parser_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",

--- a/tests/library_integration/test_parser_integration.py
+++ b/tests/library_integration/test_parser_integration.py
@@ -4,6 +4,7 @@ Tests verify parsing via engine socket with LogSchema input.
 """
 from library_integration_base import start_service, cleanup_service, free_port
 import time
+import uuid
 from pathlib import Path
 from typing import Generator
 import pytest
@@ -16,7 +17,7 @@ pytest_plugins = ["library_integration_base_fixtures"]
 @pytest.fixture(scope="function")
 def running_parser_service(tmp_path: Path) -> Generator[dict, None, None]:
     """Start the parser service with test config and yield connection info."""
-    timestamp = int(time.time() * 1000)
+    unique_id = uuid.uuid4().hex
     module_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     settings = {
         "component_type": "detectmatelibrary._testutils.dummy_parser.DummyParser",
@@ -24,7 +25,7 @@ def running_parser_service(tmp_path: Path) -> Generator[dict, None, None]:
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_parser_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_parser_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": False,

--- a/tests/library_integration/test_pipe_filereader_matcher_nvd.py
+++ b/tests/library_integration/test_pipe_filereader_matcher_nvd.py
@@ -178,31 +178,31 @@ class TestFullPipeline:
         detector_engine = running_pipeline_services["detector_engine_addr"]
         processed_logs = []
 
-        for i in range(5):
-            # Step 1: Read log
-            parser = MatcherParser(config=running_pipeline_services["parser_config"])
-            logs = [log for log in From.log(parser, AUDIT_LOG, do_process=True) if log is not None]
-            log_schema = logs[0]
+        with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as parser_socket, \
+                pynng.Pair0(dial=detector_engine, recv_timeout=2000) as detector_socket:
+            for i in range(5):
+                # Step 1: Read log
+                parser = MatcherParser(config=running_pipeline_services["parser_config"])
+                logs = [log for log in From.log(parser, AUDIT_LOG, do_process=True) if log is not None]
+                log_schema = logs[0]
 
-            # Step 2: Parse log
-            with pynng.Pair0(dial=parser_engine, recv_timeout=3000) as socket:
-                socket.send(log_schema.serialize())
-                parser_response = socket.recv()
+                # Step 2: Parse log
+                parser_socket.send(log_schema.serialize())
+                parser_response = parser_socket.recv()
 
-            parser_schema = ParserSchema()
-            parser_schema.deserialize(parser_response)
+                parser_schema = ParserSchema()
+                parser_schema.deserialize(parser_response)
 
-            processed_logs.append({
-                "original_log": log_schema.log,
-                "parsed_log": parser_schema.log,
-                "logID": log_schema.logID,
-            })
+                processed_logs.append({
+                    "original_log": log_schema.log,
+                    "parsed_log": parser_schema.log,
+                    "logID": log_schema.logID,
+                })
 
-            # Step 3: Send to Detector
-            with pynng.Pair0(dial=detector_engine, recv_timeout=2000) as socket:
-                socket.send(parser_schema.serialize())
+                # Step 3: Send to Detector
+                detector_socket.send(parser_schema.serialize())
                 try:
-                    detector_response = socket.recv()
+                    detector_response = detector_socket.recv()
                     detector_schema = DetectorSchema()
                     detector_schema.deserialize(detector_response)
                 except pynng.Timeout:

--- a/tests/library_integration/test_pipe_filereader_matcher_nvd.py
+++ b/tests/library_integration/test_pipe_filereader_matcher_nvd.py
@@ -7,7 +7,7 @@ Tests verify the full data flow where:
 """
 from detectmatelibrary.parsers.template_matcher import MatcherParser
 
-from library_integration_base import start_service, cleanup_service, AUDIT_LOG
+from library_integration_base import start_service, cleanup_service, free_port, AUDIT_LOG
 import time
 from pathlib import Path
 from subprocess import Popen
@@ -39,7 +39,7 @@ def running_pipeline_services(
         "component_config_class": "parsers.template_matcher.MatcherParserConfig",
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
-        "http_port": "8020",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
@@ -70,7 +70,7 @@ def running_pipeline_services(
         "component_config_class": "detectors.new_value_detector.NewValueDetectorConfig",
         "component_name": "test-nvd",
         "http_host": "127.0.0.1",
-        "http_port": "8030",
+        "http_port": free_port(),
         "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{timestamp}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",

--- a/tests/library_integration/test_pipe_filereader_matcher_nvd.py
+++ b/tests/library_integration/test_pipe_filereader_matcher_nvd.py
@@ -9,6 +9,7 @@ from detectmatelibrary.parsers.template_matcher import MatcherParser
 
 from library_integration_base import start_service, cleanup_service, free_port, AUDIT_LOG
 import time
+import uuid
 from pathlib import Path
 from subprocess import Popen
 from typing import Generator
@@ -30,7 +31,7 @@ def running_pipeline_services(
 ) -> Generator[dict, None, None]:
     """Start all three services (Reader, Parser, Detector) with test
     configs."""
-    timestamp = int(time.time() * 1000)
+    unique_id = uuid.uuid4().hex
     module_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
     # Parser settings
@@ -40,7 +41,7 @@ def running_pipeline_services(
         "component_name": "test-parser",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_pipeline_parser_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": True,
@@ -71,7 +72,7 @@ def running_pipeline_services(
         "component_name": "test-nvd",
         "http_host": "127.0.0.1",
         "http_port": free_port(),
-        "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{timestamp}.ipc",
+        "engine_addr": f"ipc:///tmp/test_pipeline_detector_engine_{unique_id}.ipc",
         "log_level": "DEBUG",
         "log_dir": "./logs",
         "log_to_console": True,

--- a/tests/test_engine_multi_output.py
+++ b/tests/test_engine_multi_output.py
@@ -1,6 +1,7 @@
 """Tests for Engine multi-destination output functionality."""
 import pytest
 import time
+import socket
 import pynng
 from contextlib import contextmanager
 from pydantic import ValidationError
@@ -39,6 +40,15 @@ class FailingProcessor:
 
 
 # Fixtures
+@pytest.fixture
+def free_tcp_port():
+    """Find a free port on the system, avoiding collisions under parallel test
+    runs."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('127.0.0.1', 0))
+        return s.getsockname()[1]
+
+
 @pytest.fixture
 def ipc_paths(tmp_path):
     """Generate temporary IPC paths."""
@@ -170,9 +180,9 @@ def test_no_output_destinations(ipc_paths, engine_manager):
         assert engine._state == EngineState.RUNNING
 
 
-def test_mixed_ipc_tcp_destinations(ipc_paths, engine_manager):
+def test_mixed_ipc_tcp_destinations(ipc_paths, engine_manager, free_tcp_port):
     """Engine sends to both IPC and TCP destinations."""
-    tcp_addr = 'tcp://127.0.0.1:15555'
+    tcp_addr = f'tcp://127.0.0.1:{free_tcp_port}'
     settings = create_settings(ipc_paths, [ipc_paths['out1'], tcp_addr])
 
     with pair_socket('listen', ipc_paths['out1']) as ipc_recv, \

--- a/uv.lock
+++ b/uv.lock
@@ -365,6 +365,7 @@ dev = [
     { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "types-requests" },
 ]
 
@@ -400,6 +401,7 @@ dev = [
     { name = "prek", specifier = ">=0.4.8" },
     { name = "pytest", specifier = ">=9.1.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "types-requests" },
 ]
 
@@ -410,6 +412,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1441,6 +1452,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Task
#221 

# Description

Changes
-  use CI parallelism: pytest -n 4 (reduces test run time to 1.5-2 min)
- Added free_port() helper (OS-assigned port) in library_integration_base.py; replaced all hardcoded ports. (prevents race for same port)
- Replaced millisecond timestamps with uuid.uuid4().hex for IPC socket paths. (prevent socket collision)
- tests that reconnected per-message to open one socket per test and reuse it for all sends/receives. (prevents reconnect race)
-  setup-uv was silently overriding UV_CACHE_DIR to an ephemeral per-job temp dir even with enable-cache: false. Fixed by pinning cache-local-path on the setup-uv step to the same path the cache step manages.




# How Has This Been Tested?
<!-- Please describe how you tested your changes -->

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] This Pull-Request goes to the **development** branch.
- [x] I have successfully run prek locally.
- [ ] I have added tests to cover my changes.
- [x] I have linked the issue-id to the task-description.
- [x] I have performed a self-review of my own code.
